### PR TITLE
Changes to allow_mass_assignment_of to match Rails accessible/protected logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source :gemcutter
 
-gem 'activemodel', '3.0.0.beta4'
-gem 'activerecord', '3.0.0.beta4'
-gem 'activesupport', '3.0.0.beta4'
+gem 'activemodel', '>=3.0'
+gem 'activerecord', '>=3.0'
+gem 'activesupport', '>=3.0'
 
 group :development do
   gem 'rake', '0.8.7'
@@ -11,9 +11,9 @@ group :development do
 end
 
 group :test do
-  gem 'rspec', '2.0.0.beta.11'
-  gem 'rspec-core', '2.0.0.beta.11'
-  gem 'rspec-expectations', '2.0.0.beta.11'
-  gem 'rspec-mocks', '2.0.0.beta.11'
-  gem 'rspec-rails', '2.0.0.beta.11'
+  gem 'rspec', '>=2.0'
+  gem 'rspec-core', '>=2.0'
+  gem 'rspec-expectations', '>=2.0'
+  gem 'rspec-mocks', '>=2.0'
+  gem 'rspec-rails', '>=2.0'
 end

--- a/remarkable_activerecord/lib/remarkable/active_record/matchers/allow_mass_assignment_of_matcher.rb
+++ b/remarkable_activerecord/lib/remarkable/active_record/matchers/allow_mass_assignment_of_matcher.rb
@@ -43,11 +43,19 @@ module Remarkable
         private
 
           def accessible_attributes
-            @accessible_attributes = subject_class.accessible_attributes
+            @accessible_attributes ||= unless subject_class.accessible_attributes.empty?
+              subject_class.accessible_attributes
+            else
+              subject_class.column_names - subject_class.protected_attributes.to_a
+            end
           end
 
           def protected_attributes
-            @protected_attributes = subject_class.protected_attributes
+            @protected_attributes ||= if subject_class.accessible_attributes.empty?
+              subject_class.protected_attributes
+            else
+              subject_class.column_names - subject_class.accessible_attributes.to_a
+            end
           end
       end
 


### PR DESCRIPTION
The accessible list is a whitelist: marking anything as accessible
means everything not listed is protected. Similarly, the protected
list is a blacklist: attributes not listed here are accessible.

(I couldn't figure out how to exclude another, unrelated change I made to update remarkable's gem dependencies.)
